### PR TITLE
is_password_field_name: ignore the case of the string

### DIFF
--- a/ansible_anonymizer/anonymizer.py
+++ b/ansible_anonymizer/anonymizer.py
@@ -82,7 +82,8 @@ def gen_email_address(original: Match[str]) -> str:
 
 
 def is_password_field_name(name: str) -> bool:
-    return re.search(DENYLIST_REGEX_WITH_PREFIX, name) is not None
+    flags = re.MULTILINE | re.IGNORECASE
+    return re.search(DENYLIST_REGEX_WITH_PREFIX, name, flags=flags) is not None
 
 
 def is_jinja2_expression(value: str) -> bool:

--- a/tests/test_anonymizer.py
+++ b/tests/test_anonymizer.py
@@ -36,6 +36,7 @@ def test_is_password_field_name():
     assert is_password_field_name("key_data") is True
     assert is_password_field_name("key_name") is True
     assert is_password_field_name("host_config_key") is True
+    assert is_password_field_name("quayPassword") is True
 
 
 def test_is_path():


### PR DESCRIPTION
For instance, `quayPassword` is a password field.
