### PR TITLE
Do not anonymize UUID strings (1.1.4 release)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Version 1.1.4  (2023-04-08)
+-------------
+
+- is_uuid_string(): do not anonymize UUID strings
+- test_anonymizer: add UUID test cases
+
 Version 1.1.3  (2023-04-05)
 -------------
 

--- a/ansible_anonymizer/__init__.py
+++ b/ansible_anonymizer/__init__.py
@@ -1,4 +1,4 @@
 """Top-level package for Anonymizer."""
 
 __author__ = """Red Hat"""
-__version__ = "1.1.3"
+__version__ = "1.1.4"

--- a/ansible_anonymizer/anonymizer.py
+++ b/ansible_anonymizer/anonymizer.py
@@ -94,6 +94,14 @@ def is_jinja2_expression(value: str) -> bool:
     return False
 
 
+def is_uuid_string(value: str) -> bool:
+    """Check if a given value is a UUID string"""
+    if re.match(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$", value):
+        return True
+
+    return False
+
+
 common_ipv4_networks = [
     ipaddress.IPv4Network("1.0.0.1/32"),
     ipaddress.IPv4Network("1.1.1.1/32"),
@@ -166,6 +174,8 @@ def unquote(value: str) -> str:
 
 def anonymize_field(value: str, name: str) -> str:
     v = value.strip()
+    if is_uuid_string(v):
+        return value
     if is_password_field_name(name):
         if is_path(v):
             return value

--- a/tests/test_anonymizer.py
+++ b/tests/test_anonymizer.py
@@ -22,6 +22,7 @@ from ansible_anonymizer.anonymizer import hide_user_name
 from ansible_anonymizer.anonymizer import is_jinja2_expression
 from ansible_anonymizer.anonymizer import is_password_field_name
 from ansible_anonymizer.anonymizer import is_path
+from ansible_anonymizer.anonymizer import is_uuid_string
 from ansible_anonymizer.anonymizer import redact_ip_address
 from ansible_anonymizer.anonymizer import redact_ipv4_address
 from ansible_anonymizer.anonymizer import redact_ipv6_address
@@ -417,3 +418,13 @@ def test_unquote():
     assert unquote('a') == 'a'
     assert unquote("''") == ""
     assert unquote("'") == "'"
+
+
+def test_is_uuid_string():
+    assert is_uuid_string('ce34efc1-f5e3-4b0f-bb2c-5272319589a7') is True
+
+
+def test_anonymize_uuid_field():
+    field = "uuid_field"
+    value = "ce34efc1-f5e3-4b0f-bb2c-5272319589a7"
+    assert anonymize_field(value, field) == value


### PR DESCRIPTION
For [AAP-10991](https://issues.redhat.com/browse/AAP-10991).

When 10 successive digits in a UUID string appear like (), they are recognized as a US phone number. For example, a request payload to the completion API

```python
{
  'prompt': '---\n- hosts: all\n  become: yes\n\n  tasks:\n  - name: Install nginx.\n', 
  'suggestionId': 'ce34efc1-f5e3-4b0f-bb2c-5272319589a7
}
```

is converted into:

```python
{
  'prompt': '---\n- hosts: all\n  become: yes\n\n  tasks:\n  - name: Install nginx.\n', 
  'suggestionId': 'ce34efc1-f5e3-4b0f-bb2c-(311) 555-2368a7'
}
```

This PR is for suppressing that behavior.
