### PR TITLE
comment: ensure the quotes are also removed

### DIFF
--- a/ansible_anonymizer/anonymizer.py
+++ b/ansible_anonymizer/anonymizer.py
@@ -345,18 +345,18 @@ def hide_comments(block: str) -> str:
     quotes = ""
     in_comment = False
     for c in block:
-        if c in ['"', "'"]:
-            if quotes and quotes[-1] == c:
-                quotes = quotes[:-1]
-            else:
-                quotes += c
-            new_block += c
-        elif c == "\n":
+        if c == "\n":
             in_comment = False
             quotes = ""
             new_block += c
         elif in_comment:
             continue
+        elif c in ['"', "'"]:
+            if quotes and quotes[-1] == c:
+                quotes = quotes[:-1]
+            else:
+                quotes += c
+            new_block += c
         elif c == "#" and not quotes:
             in_comment = True
             new_block = new_block.rstrip(" ")

--- a/tests/test_anonymizer.py
+++ b/tests/test_anonymizer.py
@@ -371,6 +371,15 @@ def test_anonymize_text_block_comments():
     assert hide_comments(dedent(source)) == dedent(expectation)
 
 
+def test_anonymize_comment_with_quote():
+    source = (
+        "# NEWCOPY'- "
+        "#name: using the zos_operator module, issue command PHASEIN  "
+        "#zos_operator:    cmd: 'CEMT SET PROGRAM PHASEIN'"
+    )
+    assert hide_comments(source) == ""
+
+
 def test_anonymize_text_block_user_name():
     source = """
     "documentUri": "file:///home/pierre-yves/git_repos/ansible-collections/tag_operations.yml"


### PR DESCRIPTION
This PR addresses a bug within `hide_comments()` that was causing the
the quote characters from the comments to be preserved in the final string.

E.g `# foo "var"` what transformed as `""`