### PR TITLE
hide_secrets: better management of the quotes

### DIFF
--- a/ansible_anonymizer/field_checks.py
+++ b/ansible_anonymizer/field_checks.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+
+import re
+
+# Denylist regex to TC of secrets filter
+# From detect_secrets.plugins (Apache v2 License)
+DENYLIST = (
+    "api_?key",
+    "auth_?key",
+    "service_?key",
+    "account_?key",
+    "db_?key",
+    "database_?key",
+    "priv_?key",
+    "private_?key",
+    "client_?key",
+    r"host\w*_key",
+    "db_?pass",
+    "database_?pass",
+    "key_?pass",
+    "key_?data",
+    "key_?name",
+    "password",
+    "passwd",
+    "pass",
+    "pwd",
+    "secret",
+    "contraseña",
+    "contrasena",
+    "access_key",
+)
+AFFIX_REGEX = r"\w*"
+DENYLIST_REGEX = r"|".join(DENYLIST)
+# Support for suffix after keyword i.e. password_secure = "value"
+DENYLIST_REGEX_WITH_PREFIX = fr"({DENYLIST_REGEX}){AFFIX_REGEX}"
+
+
+def is_allowed_password_field(field_name: str) -> bool:
+    """Return True if field_name should not be considered as a password."""
+    # Valid field found in sudo configuration
+    if field_name == "NOPASSWD":
+        return True
+    return False
+
+
+def is_password_field_name(name: str) -> bool:
+    flags = re.MULTILINE | re.IGNORECASE
+    if is_allowed_password_field(name):
+        return False
+    return re.search(DENYLIST_REGEX_WITH_PREFIX, name, flags=flags) is not None
+
+
+def is_jinja2_expression(value: str) -> bool:
+    """Check if an unquoted string hold a Jinja2 variable."""
+    if re.match(r"^\s*{{\s*.*?\s*}}\s*$", value):
+        return True
+
+    return False
+
+
+def is_uuid_string(value: str) -> bool:
+    """Check if a given value is a UUID string."""
+    if re.match(
+        r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+        value,
+        flags=re.IGNORECASE,
+    ):
+        return True
+
+    return False
+
+
+def is_path(content: str) -> bool:
+    # Rather conservative on purpose to avoid a false
+    # positive
+    if "/" not in content:
+        return False
+    return bool(re.match(r"^(|~)[a-z0-9_/\.-]+$", content, flags=re.IGNORECASE))

--- a/ansible_anonymizer/jinja2.py
+++ b/ansible_anonymizer/jinja2.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+
+import re
+
+
+def str_jinja2_variable_name(name: str) -> str:
+    """Sanitize a string to make it suitable to become a Jinja2 variable."""
+    name = name.replace("-", "_")
+    name = re.sub(r"[^a-z_\d]", "", name, flags=re.IGNORECASE)
+    return name.lower().lstrip("_")

--- a/ansible_anonymizer/parser.py
+++ b/ansible_anonymizer/parser.py
@@ -22,9 +22,9 @@ class NodeType(Enum):
     quoted_string_closing = 4
     new_line = 5
     space = 6
-    securized = 8
-    backslash = 9
-    deleted = 10
+    securized = 7
+    backslash = 8
+    deleted = 9
 
 
 class ParserError(Exception):

--- a/ansible_anonymizer/parser.py
+++ b/ansible_anonymizer/parser.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+
+from collections.abc import Generator
+from enum import Enum
+from typing import Literal, Optional, Union
+
+from ansible_anonymizer.field_checks import is_password_field_name, is_path
+from ansible_anonymizer.jinja2 import str_jinja2_variable_name
+
+"""Parser for YAML-like structure that tolerate error."""
+
+quote_t = Literal['"', "'"]
+
+
+class NodeType(Enum):
+    """The different type of Node returned by the parser."""
+
+    unknown = 0
+    field = 1
+    separator = 2
+    quoted_string_holder = 3
+    quoted_string_closing = 4
+    new_line = 5
+    space = 6
+    securized = 8
+    backslash = 9
+    deleted = 10
+
+
+class ParserError(Exception):
+    """Unexpected behaviour."""
+
+
+class Node:
+    """A element returned by the parser."""
+
+    def __init__(self, begin_at: int) -> None:
+        self.previous: Optional["Node"] = None
+        self.next: Optional["Node"] = None
+        self.begin_at: int = begin_at
+        self.end_at: int
+        self.text: str = ""
+        self.type: NodeType = NodeType.unknown
+        self.holder: Optional["Node"] = None
+
+        # NOTE: Fields only used with quoted strings (called `holder`)
+        self.closed_by: Optional["Node"] = None
+        self.sub: list["Node"] = []
+        self.is_protected: bool = False
+
+    def attach(self, previous: "Node") -> None:
+        """Attach a new Node to the previous one in the series."""
+        self.previous = previous
+        previous.next = self
+        holder = previous
+        while holder:
+            if holder.type is NodeType.quoted_string_holder and not holder.closed_by:
+                holder.sub.append(self)
+                self.holder = holder
+                break
+            if not holder.previous:
+                break
+            holder = holder.previous
+
+    def get_secret(self) -> Union["Node", None]:
+        """Identify the secret Node associated with the current Node."""
+        candidate = self.next
+        has_separator = False
+        print(f"FIELD={self.text}")
+        while candidate:
+            print(f"CANDIDATE: {candidate.text} ({candidate.type})")
+            if candidate.type is NodeType.space:
+                pass
+            elif candidate.type is NodeType.quoted_string_closing:
+                if candidate.holder is not self.holder:
+                    raise ParserError()
+            elif has_separator:
+                if candidate.type is NodeType.securized:
+                    # We should not come back on the same node
+                    raise ParserError
+                if candidate.type is NodeType.field:
+                    return candidate
+                if candidate.type is NodeType.unknown:
+                    return candidate
+                if candidate.type is NodeType.quoted_string_holder:
+                    return candidate
+                else:
+                    return None
+            elif candidate.type is NodeType.separator:
+                has_separator = True
+                print("HAS SEP")
+            else:
+                return None
+            candidate = candidate.next
+        return None
+
+    def is_password_field_name(self) -> bool:
+        """Return True if the field name matches the DENYLIST_REGEX regex."""
+        return is_password_field_name(self.text)
+
+    def __str__(self) -> str:
+        """Expose the Node as a string."""
+        return f"TEXT={self.text}, BEGIN_AT={self.begin_at}, TYPE={self.type}"
+
+
+def is_valid_first_character_for_a_variable(c: str) -> bool:
+    """Assuming variable names cannot start with a digit."""
+    return c.isascii() and (c.isalpha() or c in ["-", "_"])
+
+
+def is_valid_variable_character(c: str) -> bool:
+    # note: isnumeric accepts a wider range than just the 0-9
+    return c.isascii() and (c.isalpha() or c.isnumeric() or c in ["-", "_"])
+
+
+def is_field_value_sep(c: str) -> bool:
+    return c in [":", "="]
+
+
+def parser(block: str) -> Node:
+    root_node = Node(0)
+    root_node.type = NodeType.quoted_string_holder
+    current_node = root_node
+    for pos, c in enumerate(block):
+        if c == "\\":
+            new_node = Node(pos)
+            new_node.attach(previous=current_node)
+            new_node.type = NodeType.backslash
+            current_node = new_node
+        elif c in ["'", '"']:
+            is_protected = current_node.type is NodeType.backslash
+
+            holder = current_node.holder
+            while holder:
+                if (
+                    holder.text == c
+                    and holder.is_protected is is_protected
+                    and not holder.closed_by
+                ):
+                    break
+                holder = holder.holder
+
+            if holder:
+                new_node = Node(pos)
+                new_node.attach(previous=current_node)
+                new_node.type = NodeType.quoted_string_closing
+                holder.closed_by = new_node
+                current_node = new_node
+            else:
+                new_node = Node(pos)
+                new_node.type = NodeType.quoted_string_holder
+                new_node.is_protected = is_protected
+                new_node.attach(previous=current_node)
+                current_node = new_node
+        elif is_valid_first_character_for_a_variable(c):
+            if current_node.type is NodeType.field:
+                pass
+            else:
+                new_node = Node(pos)
+                new_node.attach(previous=current_node)
+                new_node.type = NodeType.field
+                current_node = new_node
+        elif is_valid_variable_character(c):
+            if current_node.type is NodeType.field:
+                pass
+            elif current_node.type is not NodeType.unknown:
+                new_node = Node(pos)
+                new_node.attach(previous=current_node)
+                current_node = new_node
+        elif is_field_value_sep(c):
+            new_node = Node(pos)
+            new_node.attach(previous=current_node)
+            new_node.type = NodeType.separator
+            current_node = new_node
+        elif c == "\n":
+            new_node = Node(pos)
+            new_node.attach(previous=current_node)
+            new_node.type = NodeType.new_line
+            current_node = new_node
+        elif c == " ":
+            new_node = Node(pos)
+            new_node.attach(previous=current_node)
+            new_node.type = NodeType.space
+            current_node = new_node
+        else:
+            if current_node.type is not NodeType.unknown:
+                new_node = Node(pos)
+                new_node.attach(previous=current_node)
+                current_node = new_node
+
+        current_node.text += c
+    return root_node
+
+
+def hide_secrets(block: str) -> str:
+    root_node = parser(block)
+    close_quotes(root_node)
+    handle_backslashes(root_node)
+    # Group substring with unknown and field types
+    # combinate_fields(root_node)
+    combinate_value_fields(root_node)
+
+    hide_secret_fields(root_node)
+
+    output = ""
+    for node in flatten(root_node):
+        output += node.text
+    return output
+
+
+def close_quotes(root_node: Node) -> None:
+    """Close the quotes that are still opened."""
+    current_node = root_node.next
+    while current_node:
+        if current_node.type is NodeType.quoted_string_holder and not current_node.closed_by:
+            current_node.type = NodeType.unknown
+        current_node = current_node.next
+
+
+def handle_backslashes(root_node: Node) -> None:
+    """
+    Convert the backslashes are regular unkown leaves.
+
+    The backslash type is only used to identify the protected quotes.
+    """
+    current_node = root_node.next
+    while current_node:
+        if current_node.type is not NodeType.backslash:
+            pass
+        elif (
+            current_node.next
+            and current_node.next.type
+            in [NodeType.quoted_string_holder, NodeType.quoted_string_closing]
+            and current_node.holder is current_node.next.holder
+        ):
+            current_node.next.text = current_node.text + current_node.next.text
+            if current_node.previous:
+                current_node.previous.next = current_node.next
+                current_node.next.previous = current_node.previous
+            current_node.text = "KILLED"
+            current_node.type = NodeType.deleted
+            current_node = current_node.next
+        else:
+            current_node.type = NodeType.unknown
+        current_node = current_node.next
+
+
+def combinate_value_fields(root_node: Node) -> None:
+    """
+    Merge the unquoted value fields.
+
+    In YAML, a value can be an unprotected string with spaces. Internally
+    the parser represent such series of spaces and fields as different
+    Node objects. Since all these objects are actually one single value,
+    we merge them together.
+    """
+    current_node = root_node
+    mergable_types = [NodeType.space, NodeType.field, NodeType.unknown]
+    post_sep = False
+    while current_node:
+        if post_sep:
+            # We ignore the first space after the : sign
+            if current_node.type is NodeType.space and current_node.next:
+                current_node = current_node.next
+
+            while (
+                current_node.type in mergable_types
+                and current_node.next
+                and current_node.next.type in mergable_types
+                and not current_node.next.is_password_field_name()
+            ):
+                current_node.type = NodeType.unknown
+                current_node.text += current_node.next.text
+                current_node.next = current_node.next.next
+                if current_node.next:
+                    current_node.next.previous = current_node
+
+        elif current_node.type is NodeType.separator and current_node.text == ":":
+            post_sep = True
+        if current_node.next is None:
+            break
+        current_node = current_node.next
+
+
+def print_node(root_node: Node) -> None:
+    for node in flatten(root_node):
+        print(node, end="")
+
+
+def flatten(node: Node) -> Generator[Node, None, None]:
+    n = node
+    while n:
+        yield n
+        if not n.next:
+            break
+        n = n.next
+
+
+def hide_secret_fields(root_node: Node) -> None:
+    def hide_quoted_string(node: Node, secret_node: Node) -> None:
+        assert secret_node.closed_by  # for mypy # noqa: S101
+        secret_node.next = secret_node.closed_by.next
+        secret_node.type = NodeType.securized
+        secret_node.text = (
+            f"{secret_node.text}{{{{ {str_jinja2_variable_name(node.text)} }}}}{secret_node.text}"
+        )
+        if secret_node.next:
+            return hide_secret_fields(secret_node.next)
+
+    def hide_regular_field(node: Node, secret_node: Node) -> None:
+        secret_node.type = NodeType.securized
+        assert secret_node.holder  # for mypy # noqa: S101
+        quote = "" if secret_node.holder.text else '"'
+        secret_node.text = f"{quote}{{{{ {str_jinja2_variable_name(node.text)} }}}}{quote}"
+        if secret_node.next:
+            return hide_secret_fields(secret_node.next)
+
+    for node in flatten(root_node):
+        if node.type is not NodeType.field:
+            continue
+        if not node.is_password_field_name():
+            continue
+
+        secret_node = node.get_secret()
+        if not secret_node:
+            continue
+        if is_path(secret_node.text):
+            continue
+
+        if secret_node.type is NodeType.quoted_string_holder:
+            return hide_quoted_string(node, secret_node)
+        else:
+            return hide_regular_field(node, secret_node)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ select = [
     "W",  # Warning
     "YTT", # flake8-2020
 ]
-ignore = ["D203", "D212", "D100", "D103", "PGH003", "D401", "SIM114", "ISC003"]
+ignore = ["D107", "D203", "D212", "D100", "D103", "PGH003", "D401", "SIM114", "ISC003"]
 
 [tool.ruff.per-file-ignores]
 "tests/test_anonymizer.py" = ["S101", "S105"]

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ commands =
 
 [flake8]
 max-line-length = 160
-ignore = C114,C116
+ignore = C114,C116,W503
 
 
 [testenv:mypy]


### PR DESCRIPTION
This PR introduces a tiny parser that can parse the YAML-like structure
and identify the fields that need to by anonymized.
The parser is tolerant to YAML format errors and can also parse
similar format like ini or toml.

Internally, the parser builds a tree. Navigation is possible:
- through the original text order, from left to right
- or right to left
- or through the different level of quoted strings.

The change will avoid the following issues:
- a trailing quote is remove with the password and we break the YAML
- quotes are inserted around the Jinja2 placeholder in a block that is
  already quoted.

Also, the PR brings a bit or code reorganization to be able to isolate the
parser in its own module file.