### PR TITLE
Parser improvements

### DIFF
--- a/ansible_anonymizer/parser.py
+++ b/ansible_anonymizer/parser.py
@@ -70,8 +70,7 @@ class Node:
             if candidate.type is NodeType.space:
                 pass
             elif candidate.type is NodeType.quoted_string_closing:
-                if candidate.holder is not self.holder:
-                    raise ParserError()
+                pass
             elif has_separator:
                 if candidate.type is NodeType.securized:
                     # We should not come back on the same node

--- a/ansible_anonymizer/parser.py
+++ b/ansible_anonymizer/parser.py
@@ -257,7 +257,7 @@ def combinate_value_fields(root_node: Node) -> None:
     while current_node:
         if post_sep:
             # We ignore the first space after the : sign
-            if current_node.type is NodeType.space and current_node.next:
+            while current_node.type is NodeType.space and current_node.next:
                 current_node = current_node.next
 
             while (

--- a/tests/test_anonymizer.py
+++ b/tests/test_anonymizer.py
@@ -639,3 +639,48 @@ def test_hide_secrets_aws_profile():
     aws_secret_access_key = "{{ aws_secret_access_key }}"
     """
     assert hide_secrets(dedent(origin)) == dedent(expectation)
+
+
+def test_parser_simple_key_value_string():
+    sample = 'config_reverseproxy_oauth_password: "passw0rd"'
+    expectation = [
+        ("", NodeType.quoted_string_holder),
+        ("config_reverseproxy_oauth_password", NodeType.field),
+        (":", NodeType.separator),
+        (" ", NodeType.space),
+        ('"', NodeType.quoted_string_holder),
+        ("passw0rd", NodeType.field),
+        ('"', NodeType.quoted_string_closing),
+    ]
+    root_node = parser(sample)
+    expanded = [(c.text, c.type) for c in flatten(root_node)]
+    assert expanded == expectation
+
+
+def test_parser_multi_spaces_before_simple_key_value_string():
+    sample = 'config_reverseproxy_oauth_password:      "passw0rd"'
+    expectation = [
+        ("", NodeType.quoted_string_holder),
+        ("config_reverseproxy_oauth_password", NodeType.field),
+        (":", NodeType.separator),
+        (" ", NodeType.space),
+        (" ", NodeType.space),
+        (" ", NodeType.space),
+        (" ", NodeType.space),
+        (" ", NodeType.space),
+        (" ", NodeType.space),
+        ('"', NodeType.quoted_string_holder),
+        ("passw0rd", NodeType.field),
+        ('"', NodeType.quoted_string_closing),
+    ]
+    root_node = parser(sample)
+    expanded = [(c.text, c.type) for c in flatten(root_node)]
+    assert expanded == expectation
+
+
+def test_hide_secrets_multi_spaces_before_simple_key_value_string():
+    sample = 'config_reverseproxy_oauth_password:      "passw0rd"'
+    assert (
+        hide_secrets(sample)
+        == 'config_reverseproxy_oauth_password:      "{{ config_reverseproxy_oauth_password }}"'
+    )

--- a/tests/test_anonymizer.py
+++ b/tests/test_anonymizer.py
@@ -752,3 +752,13 @@ def test_parser_two_passwords_on_same_line():
 def test_parser_one_password_and_one_regular_kv_on_same_line():
     sample = "my_password:      !pass w0rd  some-key: show-this"
     assert hide_secrets(sample) == 'my_password:      "{{ my_password }}"  some-key: show-this'
+
+
+def test_parser_yaml_unquoted_password_with_a_equal_sign():
+    sample = 'my_password:     !pass=w0rd"'
+    assert hide_secrets(sample) == 'my_password:     "{{ my_password }}"'
+
+
+def test_parser_ini_unquoted_password_with_a_colon_sign():
+    sample = 'my_password = !pass:w0rd"'
+    assert hide_secrets(sample) == 'my_password = "{{ my_password }}"'

--- a/tests/test_anonymizer.py
+++ b/tests/test_anonymizer.py
@@ -677,6 +677,14 @@ def test_parser_multi_spaces_before_simple_key_value_string():
     expanded = [(c.text, c.type) for c in flatten(root_node)]
     assert expanded == expectation
 
+def test_parser_get_secret():
+    sample = "config_reverseproxy_oauth_password: my_secret"
+    root_node = parser(sample)
+    list_of_nodes = list(flatten(root_node))
+    field_name_node = list_of_nodes[1]
+    assert field_name_node.text == "config_reverseproxy_oauth_password"
+    assert field_name_node.get_secret().text == "my_secret"
+
 
 def test_hide_secrets_multi_spaces_before_simple_key_value_string():
     sample = 'config_reverseproxy_oauth_password:      "passw0rd"'


### PR DESCRIPTION
- Accept a `:` or `=` character in a password field as soon as it's not also the field delimiter.
- Improve the way the unquoted password are handled (e.g `my-password: !123#!`)
- Ignore multiple spaces after the delimiter.
- remove a broken sanity check that was raising ParserError exception in some cases.

Closes: #44