### PR TITLE
generalize the use of hide_secrets()

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,6 +48,7 @@ repos:
       entry: mypy
       language: python
       types: [python]
+      args: [--no-strict-optional]
       additional_dependencies:
         - mypy
         - types-PyYAML

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ select = [
     "W",  # Warning
     "YTT", # flake8-2020
 ]
-ignore = ["D107", "D203", "D212", "D100", "D103", "PGH003", "D401", "SIM114", "ISC003"]
+ignore = ["D107", "D203", "D212", "D100", "D103", "PGH003", "D401", "SIM114", "ISC003", "SIM108"]
 
 [tool.ruff.per-file-ignores]
 "tests/test_anonymizer.py" = ["S101", "S105"]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -6,152 +6,135 @@ from textwrap import dedent
 
 from ansible_anonymizer.parser import (
     NodeType,
+    breakup_elements,
     combinate_value_fields,
     flatten,
-    hide_secrets,
-    parser,
+    parse_raw_block,
 )
 
 
-def test_hide_secret_sudo_line():
-    source = 'line="%wheel\tALL=(ALL)\tNOPASSWD: ALL"'
-    assert hide_secrets(source) == source
-
-
-def test_hide_secrets_quoted():
-    assert (
-        hide_secrets("ansible: 'ALL=(ALL) PASSWD: \\\"{{NOPASSWD'")
-        == "ansible: 'ALL=(ALL) PASSWD: {{ passwd }}'"
-    )
-    assert (
-        hide_secrets("ansible: 'ALL=(ALL) PASSWD: \\\"{{NOPASSWD'")
-        == "ansible: 'ALL=(ALL) PASSWD: {{ passwd }}'"
-    )
-    assert (
-        hide_secrets("password1: 'foobar'\npassword: 'barfoo'")
-        == "password1: '{{ password1 }}'\npassword: '{{ password }}'"
-    )
-    assert (
-        hide_secrets('%wheel	ALL=(ALL)	PASSWD: "ALL"')
-        == '%wheel	ALL=(ALL)	PASSWD: "{{ passwd }}"'  # noqa: E501
-    )
-
-
-def test_hide_secrets_preserve_protected_quotes():
-    assert (
-        hide_secrets('line: "%ansible password=\'foobar\'"')
-        == 'line: "%ansible password=\'{{ password }}\'"'
-    )
-
-
 def test_hide_secrets_trailing_secret():
-    origin = "password1: foobar\npassword: barfoo"
-    expectation = 'password1: "{{ password1 }}"\npassword: "{{ password }}"'
-    assert hide_secrets(origin) == expectation
+    sample = "password1: foobar\npassword: barfoo"
+    root_node = parse_raw_block(sample)
+    passwords = {
+        t.secret_value_of.text: t.text for t in flatten(root_node) if t.type is NodeType.secret
+    }
+    assert passwords == {"password1": "foobar", "password": "barfoo"}
 
 
 def test_hide_secrets_quoted_field():
-    origin = """
+    sample = """
     "password9": "my_password10: maxplus"
     """
-    expectation = """
-    "password9": "{{ password9 }}"
-    """
-    assert hide_secrets(origin) == expectation
+    root_node = parse_raw_block(sample)
+    passwords = {
+        t.secret_value_of.text: t.text for t in flatten(root_node) if t.type is NodeType.secret
+    }
+    assert passwords == {"password9": "my_password10: maxplus"}
 
 
-def test_hide_secrets_unquoted_field():
-    origin = """
+def test_parse_secrets_unquoted_field():
+    sample = """
     password9: "my_password10: maxplus"
     """
-    expectation = """
-    password9: "{{ password9 }}"
-    """
-    assert hide_secrets(origin) == expectation
+    root_node = parse_raw_block(sample)
+    passwords = {
+        t.secret_value_of.text: t.text for t in flatten(root_node) if t.type is NodeType.secret
+    }
+    assert passwords == {"password9": "my_password10: maxplus"}
 
 
-def test_hide_secrets_pattern_within_quoted_string():
-    origin = """
+def test_parse_secrets_pattern_within_quoted_string():
+    sample = """
     'password9: "my_password10: maxplus"'
     """
-    expectation = """
-    'password9: "{{ password9 }}"'
-    """
-    assert hide_secrets(origin) == expectation
+    root_node = parse_raw_block(sample)
+    passwords = {
+        t.secret_value_of.text: t.text for t in flatten(root_node) if t.type is NodeType.secret
+    }
+    assert passwords == {"password9": "my_password10: maxplus"}
 
 
-def test_hide_secrets_long_string():
-    origin = """
+def test_parse_secrets_long_string():
+    sample = """
     passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
     """  # noqa: E501
-    expectation = """
-    passwd: "{{ passwd }}"
-    """
-    assert hide_secrets(origin) == expectation
+    root_node = parse_raw_block(sample)
+    passwords = {
+        t.secret_value_of.text: t.text for t in flatten(root_node) if t.type is NodeType.secret
+    }
+    assert passwords == {
+        "passwd": (
+            "$6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizo"
+            "uQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/"
+        )
+    }
 
 
-def test_hide_secrets_2_level_of_quotes():
-    origin = """
+def test_parse_secrets_2_level_of_quotes():
+    sample = """
     "aaa'
        passwd: bob'"
     """
-    expectation = """
-    "aaa'
-       passwd: {{ passwd }}'"
-    """
-    assert hide_secrets(origin) == expectation
+    root_node = parse_raw_block(sample)
+    passwords = {
+        t.secret_value_of.text: t.text for t in flatten(root_node) if t.type is NodeType.secret
+    }
+    assert passwords == {"passwd": "bob"}
 
 
-def test_hide_secrets_protected_double_quotes():
-    origin = """
+def test_parse_secrets_protected_double_quotes():
+    sample = """
     "aaa
        \\"passwd: bob\\""
     """
-    expectation = """
-    "aaa
-       \\"passwd: {{ passwd }}\\""
-    """
-    assert hide_secrets(origin) == expectation
+    root_node = parse_raw_block(sample)
+    passwords = {
+        t.secret_value_of.text: t.text for t in flatten(root_node) if t.type is NodeType.secret
+    }
+    assert passwords == {"passwd": "bob"}
 
 
-def test_hide_secrets_empty():
-    origin = ""
-    expectation = ""
-    assert hide_secrets(origin) == expectation
+def test_parse_secrets_empty():
+    sample = ""
+    root_node = parse_raw_block(sample)
+    nodes = list(flatten(root_node))
+    assert len(nodes) == 1
 
 
-def test_hide_secrets_field_only():
-    origin = "passwd"
-    expectation = "passwd"
-    assert hide_secrets(origin) == expectation
+def test_parse_secrets_field_only():
+    sample = "passwd"
+    root_node = parse_raw_block(sample)
+    nodes = list(flatten(root_node))
+    assert len(nodes) == 2
+    assert nodes[-1].text == sample
 
 
-def test_hide_secrets_vars_file():
-    origin = """
+def test_parse_secrets_vars_file():
+    sample = """
     ansible_user: root
     ansible_host: esxi1-gw.ws.testing.ansible.com
     ansible_password: '!234AaAa56'
     """
-    expectation = """
-    ansible_user: root
-    ansible_host: esxi1-gw.ws.testing.ansible.com
-    ansible_password: '{{ ansible_password }}'
-    """
-    assert hide_secrets(dedent(origin)) == dedent(expectation)
+    root_node = parse_raw_block(sample)
+    passwords = {
+        t.secret_value_of.text: t.text for t in flatten(root_node) if t.type is NodeType.secret
+    }
+    assert passwords == {"ansible_password": "!234AaAa56"}
 
 
-def test_hide_secrets_unquoted_string():
-    origin = """
+def test_parse_secrets_unquoted_string():
+    sample = """
     ansible_password: an unquoted string
     """
-    expectation = """
-    ansible_password: "{{ ansible_password }}"
-    """
-    assert hide_secrets(dedent(origin)) == dedent(expectation)
+    root_node = parse_raw_block(dedent(sample))
+    nodes = list(flatten(root_node))
+    assert nodes[-2].text == "an unquoted string"
+    assert nodes[-2].secret_value_of.text == "ansible_password"
 
 
-def test_hide_secrets_multi_secrets():
-    origin = """
+def test_parse_secrets_multi_secrets():
+    sample = """
     '(?i)password1:': "{{ _iosxr_password }}"
     "this is somethingpass: password2: else my_password3: 'password4: _Agaim': barfoo"
     password5: maxplus
@@ -163,33 +146,24 @@ def test_hide_secrets_multi_secrets():
 
     passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
     """  # noqa: E501
-    expectation = """
-    '(?i)password1:': "{{ _iosxr_password }}"
-    "this is somethingpass: {{ somethingpass }}: else my_password3: '{{ my_password3 }}': barfoo"
-    password5: "{{ password5 }}"
-    password6: "{{ password6 }}"
-    password7: "{{ password7 }}"
-    "password9": "{{ password9 }}"
-    password11: "{{ password11 }}"
-
-    passwd: "{{ passwd }}"
-    """
-    assert hide_secrets(origin) == expectation
-
-
-def test_hide_secrets_aws_profile():
-    origin = """
-    [my-secret-account]
-    aws_access_key_id = BJIA5UUFYYOOKZQODC3F
-    aws_secret_access_key = NeTL/2vPPnlnb/8RBtsw3EwnNjflDbgZiDmRskhb
-    """
-
-    expectation = """
-    [my-secret-account]
-    aws_access_key_id = "{{ aws_access_key_id }}"
-    aws_secret_access_key = "{{ aws_secret_access_key }}"
-    """
-    assert hide_secrets(dedent(origin)) == dedent(expectation)
+    root_node = parse_raw_block(sample)
+    passwords = {
+        t.secret_value_of.text: t.text for t in flatten(root_node) if t.type is NodeType.secret
+    }
+    assert passwords == {
+        "somethingpass": "password2",
+        "my_password3": "password4: _Agaim",
+        "password5": "maxplus",
+        "password6": "maxplus",
+        "password7": "my_password8: maxplus",
+        "password9": "my_password10: maxplus",
+        "password11": "my_password12:\n              maxplus",
+        "passwd": (
+            "$6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3n"
+            "yNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9"
+            "BZMN1O/"
+        ),
+    }
 
 
 def test_parser_simple_key_value_string():
@@ -203,7 +177,7 @@ def test_parser_simple_key_value_string():
         ("passw0rd", NodeType.field),
         ('"', NodeType.quoted_string_closing),
     ]
-    root_node = parser(sample)
+    root_node = breakup_elements(sample)
     expanded = [(c.text, c.type) for c in flatten(root_node)]
     assert expanded == expectation
 
@@ -224,14 +198,14 @@ def test_parser_multi_spaces_before_simple_key_value_string():
         ("passw0rd", NodeType.field),
         ('"', NodeType.quoted_string_closing),
     ]
-    root_node = parser(sample)
+    root_node = breakup_elements(sample)
     expanded = [(c.text, c.type) for c in flatten(root_node)]
     assert expanded == expectation
 
 
 def test_parser_get_secret():
     sample = "config_reverseproxy_oauth_password: my_secret"
-    root_node = parser(sample)
+    root_node = breakup_elements(sample)
     list_of_nodes = list(flatten(root_node))
     field_name_node = list_of_nodes[1]
     assert field_name_node.text == "config_reverseproxy_oauth_password"
@@ -240,11 +214,11 @@ def test_parser_get_secret():
 
 def test_parser_get_secret_with_unquoted_special_chars():
     sample = "config_reverseproxy_oauth_password: %$#my_secret&"
-    root_node = parser(sample)
+    root_node = breakup_elements(sample)
     field_name_node = root_node.next
     assert field_name_node.text == "config_reverseproxy_oauth_password"
     # Without combinate_value_fields we only get the first node of the secret
-    assert field_name_node.get_secret().text == "%$#"
+    assert field_name_node.get_secret().text == "%"
     combinate_value_fields(root_node)
     assert field_name_node.get_secret().text == "%$#my_secret&"
 
@@ -259,7 +233,7 @@ def test_parser_get_secret_with_ini_file():
     [section.bar]
     George = # a comment
     """
-    root_node = parser(dedent(sample))
+    root_node = breakup_elements(dedent(sample))
     secret_node = [n for n in flatten(root_node) if n.text == "turbo_secret"][0]
     # Without combinate_value_fields we only get the first node of the secret
     combinate_value_fields(root_node)
@@ -268,51 +242,116 @@ def test_parser_get_secret_with_ini_file():
 
 def test_combinate_value_fields():
     sample = "config_reverseproxy_oauth_password: my!secret%$!"
-    root_node = parser(sample)
-    assert len(list(flatten(root_node))) == 8
+    root_node = breakup_elements(sample)
+    assert len(list(flatten(root_node))) == 10
     combinate_value_fields(root_node)
     assert len(list(flatten(root_node))) == 5
 
 
 def test_hide_secrets_multi_spaces_before_simple_key_value_string():
     sample = 'config_reverseproxy_oauth_password:      "passw0rd"'
-    assert (
-        hide_secrets(sample)
-        == 'config_reverseproxy_oauth_password:      "{{ config_reverseproxy_oauth_password }}"'
-    )
+    root_node = parse_raw_block(sample)
+    nodes = list(flatten(root_node))
+    assert nodes[-2].text == "passw0rd"
+    assert nodes[-2].type is NodeType.secret
 
 
 def test_parser_unquoted_password_with_special_chars():
     sample = 'my_password=      !pass w0rd"'
-    assert hide_secrets(sample) == 'my_password=      "{{ my_password }}"'
+    root_node = parse_raw_block(sample)
+    nodes = list(flatten(root_node))
+    assert [t.type for t in nodes] == [
+        NodeType.quoted_string_holder,
+        NodeType.field,
+        NodeType.separator,
+        NodeType.space,
+        NodeType.space,
+        NodeType.space,
+        NodeType.space,
+        NodeType.space,
+        NodeType.space,
+        NodeType.secret,
+    ]
+    assert nodes[-1].type is NodeType.secret
+    assert nodes[-1].text == '!pass w0rd"'
 
 
 def test_parser_two_passwords_on_same_line():
     sample = 'my_password:      !pass w0rd  another_password: hide_thís "'
-    assert (
-        hide_secrets(sample)
-        == 'my_password:      "{{ my_password }}"  another_password: "{{ another_password }}"'
-    )
+    root_node = parse_raw_block(sample)
+    nodes = list(flatten(root_node))
+    assert [t.type for t in nodes] == [
+        NodeType.quoted_string_holder,
+        NodeType.field,
+        NodeType.separator,
+        NodeType.space,
+        NodeType.space,
+        NodeType.space,
+        NodeType.space,
+        NodeType.space,
+        NodeType.space,
+        NodeType.secret,
+        NodeType.space,
+        NodeType.space,
+        NodeType.field,
+        NodeType.separator,
+        NodeType.space,
+        NodeType.secret,
+    ]
+    assert nodes[9].type is NodeType.secret
+    assert nodes[9].text == "!pass w0rd"
+
+    assert nodes[-1].type is NodeType.secret
+    assert nodes[-1].text == 'hide_thís "'
 
 
 def test_parser_one_password_and_one_regular_kv_on_same_line():
     sample = "my_password:      !pass w0rd  some-key: show-this"
-    assert hide_secrets(sample) == 'my_password:      "{{ my_password }}"  some-key: show-this'
+    root_node = parse_raw_block(sample)
+    nodes = list(flatten(root_node))
+    assert [t.type for t in nodes] == [
+        NodeType.quoted_string_holder,
+        NodeType.field,
+        NodeType.separator,
+        NodeType.space,
+        NodeType.space,
+        NodeType.space,
+        NodeType.space,
+        NodeType.space,
+        NodeType.space,
+        NodeType.secret,
+        NodeType.space,
+        NodeType.space,
+        NodeType.field,
+        NodeType.separator,
+        NodeType.space,
+        NodeType.field,
+    ]
+    assert nodes[9].type is NodeType.secret
+    assert nodes[9].text == "!pass w0rd"
 
 
 def test_parser_yaml_unquoted_password_with_a_equal_sign():
     sample = 'my_password:     !pass=w0rd"'
-    assert hide_secrets(sample) == 'my_password:     "{{ my_password }}"'
+    root_node = parse_raw_block(sample)
+    nodes = list(flatten(root_node))
+    assert nodes[-1].secret_value_of is nodes[1]
+    assert nodes[-1].type is NodeType.secret
+    assert nodes[-1].text == '!pass=w0rd"'
 
 
 def test_parser_ini_unquoted_password_with_a_colon_sign():
     sample = 'my_password = !pass:w0rd"'
-    assert hide_secrets(sample) == 'my_password = "{{ my_password }}"'
+    root_node = parse_raw_block(sample)
+    nodes = list(flatten(root_node))
+    assert nodes[-1].secret_value_of is nodes[1]
+    assert nodes[-1].type is NodeType.secret
+    assert nodes[-1].text == '!pass:w0rd"'
 
 
 def test_parser_empty_quoted_secret():
     sample = 'password=""'
-    root_node = parser(sample)
+    root_node = breakup_elements(sample)
     node_types_found = [n.type for n in flatten(root_node)]
     assert node_types_found == [
         NodeType.quoted_string_holder,
@@ -327,7 +366,7 @@ def test_parser_empty_quoted_secret():
 
 def test_parser_one_character_quoted_secret():
     sample = 'password="a"'
-    root_node = parser(sample)
+    root_node = breakup_elements(sample)
     node_types_found = [n.type for n in flatten(root_node)]
     assert node_types_found == [
         NodeType.quoted_string_holder,


### PR DESCRIPTION
The new `parse_raw_block()` method returns a Node tree that describe the
text block. The method is used by `ansible_anonymizer.anonymizer` which
applies `anonymize_field()` to hide the passwords.
`parser.py` is fully dedicated to the parsing of text. This isolation allow
us to use `hide_screts()` everywhere and avoid circular reference.

Also call `mypy` with `--no-strict-optional` to avoid the extra warnings caused by the use of `Optional`.
