### PR TITLE
fix: anonymize_struct uses the right value_template with text block

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Version 1.4.1 (2023-06-14)
+-------------
+
+- fix to ensure anonymize_struct() uses the right value_template when it anoymizes a text blocks
+
 Version 1.4.0 (2023-06-13)
 -------------
 

--- a/ansible_anonymizer/__init__.py
+++ b/ansible_anonymizer/__init__.py
@@ -1,4 +1,4 @@
 """Top-level package for Anonymizer."""
 
 __author__ = """Red Hat"""
-__version__ = "1.4.0"
+__version__ = "1.4.1"

--- a/ansible_anonymizer/anonymizer.py
+++ b/ansible_anonymizer/anonymizer.py
@@ -130,7 +130,7 @@ def anonymize_field(value: str, name: str, value_template: Template) -> str:
             return unquote(v)
         variable_name = str_jinja2_variable_name(name)
         return value_template.substitute(variable_name=variable_name)
-    return anonymize_text_block(value)
+    return anonymize_text_block(value, value_template=value_template)
 
 
 def anonymize_struct(o: Any, key_name: str = "", value_template: Optional[Template] = None) -> Any:

--- a/tests/test_anonymizer.py
+++ b/tests/test_anonymizer.py
@@ -89,8 +89,9 @@ def test_anonymize_email():
 
 
 def test_anonymize_with_special_template():
-    original = {"password": ["first_password", "second_password"]}
-    expected = {"password": ["ö", "ö"]}
+    original = {"password": ["first_password", "second_password"], "block": 'password1: "bar"'}
+    expected = {"password": ["ö", "ö"], "block": 'password1: "ö"'}
+    value_template = Template("ö")
     value_template = Template("ö")
     assert anonymize_struct(original, value_template=value_template) == expected
 


### PR DESCRIPTION
Ensure anonymize_struct() uses the right value_template when it anoymizes a text blocks.
